### PR TITLE
do not leak lock releases

### DIFF
--- a/reposerver/repository/repository.go
+++ b/reposerver/repository/repository.go
@@ -603,12 +603,12 @@ func (s *Service) runManifestGenAsync(ctx context.Context, repoRoot, commitSHA, 
 
 						refSourceMapping, ok := q.RefSources[refVar]
 						if !ok {
+							if len(q.RefSources) == 0 {
+								ch.errCh <- fmt.Errorf("source referenced %q, but no source has a 'ref' field defined", refVar)
+							}
 							refKeys := make([]string, 0)
 							for refKey := range q.RefSources {
 								refKeys = append(refKeys, refKey)
-							}
-							if len(refKeys) == 0 {
-								ch.errCh <- fmt.Errorf("source referenced %q, but no source has a 'ref' field defined", refVar)
 							}
 							ch.errCh <- fmt.Errorf("source referenced %q, which is not one of the available sources (%s)", refVar, strings.Join(refKeys, ", "))
 							return


### PR DESCRIPTION
There were places where we could return before setting up the lock releases.

deferring the lock release _immediately_ after locking the repo makes sure we don't perma-lock any repos.

I also added a check to prevent deadlocks when a source references the same repo at a different revision.